### PR TITLE
check for pdaSubType to be "POKT DNA" updated

### DIFF
--- a/src/pda/interfaces/pda.interface.ts
+++ b/src/pda/interfaces/pda.interface.ts
@@ -25,10 +25,10 @@ export interface IssuedPDA {
     claim:
       | (PDAClaimBase<'citizen'> & {
           pdaSubtype: 'POKT DAO';
-          votingAddress: string;
         })
       | (PDAClaimBase<'citizen'> & {
           pdaSubtype: 'POKT DNA';
+          votingAddress: string;
         })
       | PDAClaimBase<'builder'>
       | (PDAClaimBase<'staker'> & StakerPDAClaim);

--- a/src/scoring/scoring.service.ts
+++ b/src/scoring/scoring.service.ts
@@ -196,7 +196,7 @@ export class ScoringService {
 
       if (
         PDA_TYPE === 'citizen' &&
-        PDA.dataAsset.claim.pdaSubtype === 'POKT DAO'
+        PDA.dataAsset.claim.pdaSubtype === 'POKT DNA'
       ) {
         GIDToEthVotingAddr[GATEWAY_ID] = PDA.dataAsset.claim.votingAddress;
       }


### PR DESCRIPTION
According to task board on notion, we should check citizen PDA with “POKT DNA” sub type , not "POKT DAO".