### PR TITLE
adding PDAs to canBeScoredPDAs fixed

### DIFF
--- a/src/scoring/scoring.service.ts
+++ b/src/scoring/scoring.service.ts
@@ -207,9 +207,9 @@ export class ScoringService {
 
       const GATEWAY_ID = PDA.dataAsset.owner.gatewayId;
       const PDA_TYPE = PDA.dataAsset.claim.pdaType;
-      const ETH_VOTING_ADDR = GIDToEthVotingAddr[GATEWAY_ID];
 
       if (GATEWAY_ID in GIDToEthVotingAddr) {
+        const ETH_VOTING_ADDR = GIDToEthVotingAddr[GATEWAY_ID];
         // Create empty object for new EthVotingaddress
         this.appendETHVotingAddr(scoresOutput, ETH_VOTING_ADDR);
 

--- a/src/scoring/scoring.service.ts
+++ b/src/scoring/scoring.service.ts
@@ -68,7 +68,7 @@ export class ScoringService {
       let hasDAOBadge: boolean = false,
         hasDNABadge: boolean = false;
 
-      // check exists of badges
+      // Check exists of badges
       for (let index = 0; index < pointer.PDAs.length; index++) {
         const PDASubType = pointer.PDAs[index].dataAsset.claim.pdaSubtype;
 
@@ -84,7 +84,7 @@ export class ScoringService {
         }
       }
 
-      // assign point when all badges achieved
+      // Assign point when all badges achieved
       if (hasDAOBadge && hasDNABadge) {
         pointer.point = 1;
       }
@@ -185,63 +185,55 @@ export class ScoringService {
   calculateScores(PDAs: Array<IssuedPDA>): PDAScores<ScoringDomainBlock> {
     const scoresOutput: PDAScores<ScoringDomainBlock> = {};
     const GIDToEthVotingAddr: Record<string, string> = {};
-    const canBeScoredPDAs: Array<IssuedPDA> = [];
 
-    // find voting address and PDAs that can be scored
+    // Find voting address and PDAs that can be scored
     for (let index = 0; index < PDAs.length; index++) {
       const PDA = PDAs[index];
 
       const GATEWAY_ID = PDA.dataAsset.owner.gatewayId;
-      // const PDA_TYPE = PDA.dataAsset.claim.pdaType;
+      const PDA_TYPE = PDA.dataAsset.claim.pdaType;
 
-      const PDA_check: any = lodash.find(PDAs, (PDA_check) => {
-        return (
-          PDA_check.dataAsset.claim.pdaType === 'citizen' &&
-          PDA_check.dataAsset.claim.pdaSubtype === 'POKT DAO' &&
-          PDA_check.dataAsset.owner.gatewayId === PDA.dataAsset.owner.gatewayId
-        );
-      });
-      if (PDA_check && !(GATEWAY_ID in GIDToEthVotingAddr)) {
-        GIDToEthVotingAddr[GATEWAY_ID] =
-          PDA_check.dataAsset.claim.votingAddress;
-      }
-
-      if (GATEWAY_ID in GIDToEthVotingAddr) {
-        canBeScoredPDAs.push(PDA);
+      if (
+        PDA_TYPE === 'citizen' &&
+        PDA.dataAsset.claim.pdaSubtype === 'POKT DAO'
+      ) {
+        GIDToEthVotingAddr[GATEWAY_ID] = PDA.dataAsset.claim.votingAddress;
       }
     }
 
-    // calculate scores of PDAs that can be scored
-    for (let index = 0; index < canBeScoredPDAs.length; index++) {
-      const PDA = canBeScoredPDAs[index];
+    // Calculate scores of PDAs that can be scored
+    for (let index = 0; index < PDAs.length; index++) {
+      const PDA = PDAs[index];
 
       const GATEWAY_ID = PDA.dataAsset.owner.gatewayId;
       const PDA_TYPE = PDA.dataAsset.claim.pdaType;
       const ETH_VOTING_ADDR = GIDToEthVotingAddr[GATEWAY_ID];
 
-      // Create empty object for new gatewayID
-      this.appendETHVotingAddr(scoresOutput, ETH_VOTING_ADDR);
+      if (GATEWAY_ID in GIDToEthVotingAddr) {
+        // Create empty object for new EthVotingaddress
+        this.appendETHVotingAddr(scoresOutput, ETH_VOTING_ADDR);
 
-      if (PDA_TYPE === 'citizen') {
-        // Create empty object with initial values for citizen domain
-        this.appendDomainBlock(scoresOutput, ETH_VOTING_ADDR, PDA_TYPE);
-        // calculate point and append PDAs
-        this.calculateCitizensPoint(scoresOutput, ETH_VOTING_ADDR, PDA);
-      } else if (PDA_TYPE === 'builder') {
-        // Create empty object with initial values for builder domain
-        this.appendDomainBlock(scoresOutput, ETH_VOTING_ADDR, PDA_TYPE);
-        // Calculate point and append PDAs
-        this.calculateBuildersPoint(scoresOutput, ETH_VOTING_ADDR, PDA);
-      } else if (PDA_TYPE === 'staker') {
-        // Create empty object with initial values for staker domain
-        this.appendDomainBlock(scoresOutput, ETH_VOTING_ADDR, PDA_TYPE);
-        // Calculate point and append PDAs
-        this.calculateStakersPoint(scoresOutput, ETH_VOTING_ADDR, PDA);
-      } else {
-        this.logger.error(
-          `Unknown PDA type (${PDA_TYPE}) exists`,
-          ScoringService.name,
-        );
+        if (PDA_TYPE === 'citizen') {
+          // Create empty object with initial values for citizen domain
+          this.appendDomainBlock(scoresOutput, ETH_VOTING_ADDR, PDA_TYPE);
+          // Calculate point and append PDAs
+          this.calculateCitizensPoint(scoresOutput, ETH_VOTING_ADDR, PDA);
+        } else if (PDA_TYPE === 'builder') {
+          // Create empty object with initial values for builder domain
+          this.appendDomainBlock(scoresOutput, ETH_VOTING_ADDR, PDA_TYPE);
+          // Calculate point and append PDAs
+          this.calculateBuildersPoint(scoresOutput, ETH_VOTING_ADDR, PDA);
+        } else if (PDA_TYPE === 'staker') {
+          // Create empty object with initial values for staker domain
+          this.appendDomainBlock(scoresOutput, ETH_VOTING_ADDR, PDA_TYPE);
+          // Calculate point and append PDAs
+          this.calculateStakersPoint(scoresOutput, ETH_VOTING_ADDR, PDA);
+        } else {
+          this.logger.error(
+            `Unknown PDA type (${PDA_TYPE}) exists`,
+            ScoringService.name,
+          );
+        }
       }
     }
 

--- a/src/scoring/scoring.service.ts
+++ b/src/scoring/scoring.service.ts
@@ -192,13 +192,18 @@ export class ScoringService {
       const PDA = PDAs[index];
 
       const GATEWAY_ID = PDA.dataAsset.owner.gatewayId;
-      const PDA_TYPE = PDA.dataAsset.claim.pdaType;
+      // const PDA_TYPE = PDA.dataAsset.claim.pdaType;
 
-      if (
-        PDA_TYPE === 'citizen' &&
-        PDA.dataAsset.claim.pdaSubtype === 'POKT DAO'
-      ) {
-        GIDToEthVotingAddr[GATEWAY_ID] = PDA.dataAsset.claim.votingAddress;
+      const PDA_check: any = lodash.find(PDAs, (PDA_check) => {
+        return (
+          PDA_check.dataAsset.claim.pdaType === 'citizen' &&
+          PDA_check.dataAsset.claim.pdaSubtype === 'POKT DAO' &&
+          PDA_check.dataAsset.owner.gatewayId === PDA.dataAsset.owner.gatewayId
+        );
+      });
+      if (PDA_check && !(GATEWAY_ID in GIDToEthVotingAddr)) {
+        GIDToEthVotingAddr[GATEWAY_ID] =
+          PDA_check.dataAsset.claim.votingAddress;
       }
 
       if (GATEWAY_ID in GIDToEthVotingAddr) {


### PR DESCRIPTION
As I see , for a user that has 2 PDAs with POKT DNA & POKT DAO values, If in our for loop,  POKT DNA  comes as the first PDA, 
the user citizenship point will be 0 ( we expect it to be 1).
please take a look at it and let me know if I am on the wrong page.